### PR TITLE
Download from upstream swipl/msgpackc

### DIFF
--- a/pack.pl
+++ b/pack.pl
@@ -1,5 +1,5 @@
 name(msgpackc).
-version('0.1.0').
+version('0.1.1').
 title('C-Based Message Pack for SWI-Prolog').
 author('Roy Ratcliffe', 'royratcliffe@me.com').
 packager('Roy Ratcliffe', 'royratcliffe@me.com').

--- a/pack.pl
+++ b/pack.pl
@@ -4,5 +4,5 @@ title('C-Based Message Pack for SWI-Prolog').
 author('Roy Ratcliffe', 'royratcliffe@me.com').
 packager('Roy Ratcliffe', 'royratcliffe@me.com').
 maintainer('Roy Ratcliffe', 'royratcliffe@me.com').
-home('https://github.com/royratcliffe/msgpackc-prolog').
-download('https://github.com/royratcliffe/msgpackc-prolog/releases/*.zip').
+home('https://github.com/swipl/msgpackc').
+download('https://github.com/swipl/msgpackc/releases/*.zip').

--- a/prolog/msgpackc.pl
+++ b/prolog/msgpackc.pl
@@ -175,8 +175,30 @@ msgpack_object(Map) -->
     !.
 msgpack_object(ext(Ext)) --> msgpack_ext(Ext).
 
+%!  msgpack_key(?Key:atomic)// is semidet.
+%
+%   SWI Prolog dictionaries require atomic keys. Message packing allows
+%   _any_ key types including arrays, sub-map, binaries and extensions.
+%   Map keys are only integer or atom under Prolog. Fail therefore for
+%   any other types; use msgpack//1 to accept non-atomic maps with keys
+%   of any kind.
+%
+%   @arg Key integer or atom used as map pair key.
+
 msgpack_key(Key) --> msgpack_int(Key), !.
-msgpack_key(Key) --> msgpack_str(Key).
+msgpack_key(Key) -->
+    { var(Key),
+      !
+    },
+    msgpack_str(Str),
+    { atom_string(Key, Str)
+    },
+    !.
+msgpack_key(Key) -->
+    { atom(Key),
+      atom_string(Key, Str)
+    },
+    msgpack_str(Str).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/prolog/msgpackc.plt
+++ b/prolog/msgpackc.plt
@@ -9,6 +9,9 @@ test(msgpack, true(B == map([int(1)-str("x")]))) :-
     phrase(msgpack(map([int(1)-str("x")])), A),
     phrase(msgpack(B), A).
 
+test(msgpack, true(B == map([str("a")-int(1)]))) :-
+    phrase(msgpack_object(_{a:1}), A), phrase(msgpack(B), A).
+
 test(msgpack_object, true(A == [0x80])) :-
     phrase(msgpack_object(_{}), A).
 test(msgpack_object, true(A == B{})) :-


### PR DESCRIPTION
SWI-Prolog does not like hyphen (-) in the pack name.